### PR TITLE
Add notification

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,8 +71,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password,
-                                  :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :notification_option)
   end
 
   def correct_user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,4 +10,11 @@ class UserMailer < ApplicationMailer
 
     mail to: user.email, subject: 'Password reset'
   end
+
+  def follower_increase_notification(follower, followed)
+    @follower = follower
+    @followed = followed
+
+    mail to: @followed.email, subject: 'follower increase!'
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,6 +15,8 @@ class UserMailer < ApplicationMailer
     @follower = follower
     @followed = followed
 
+    return nil unless @followed.notification_option
+
     mail to: @followed.email, subject: 'follower increase!'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,10 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
+  def follower_increase_notification(followed)
+    UserMailer.follower_increase_notification(self, followed).deliver_now
+  end
+
   def feed
     following_ids = 'SELECT followed_id FROM relationships WHERE follower_id = :user_id'
     Micropost.where("user_id IN (#{following_ids}) OR user_id = :user_id", user_id: id)
@@ -75,6 +79,7 @@ class User < ApplicationRecord
 
   def follow(other_user)
     active_relationships.create(followed_id: other_user.id)
+    follower_increase_notification(other_user)
   end
 
   def unfollow(other_user)

--- a/app/views/user_mailer/follower_increase_notification.html.haml
+++ b/app/views/user_mailer/follower_increase_notification.html.haml
@@ -1,0 +1,4 @@
+%h1 follower increase!
+%p
+  フォロワーが増えました。
+  = @follower.name

--- a/app/views/user_mailer/follower_increase_notification.text.haml
+++ b/app/views/user_mailer/follower_increase_notification.text.haml
@@ -1,0 +1,6 @@
+follower increase!
+フォロワーが増えました。
+= @follower.name
+
+フォロワーのページにアクセスしましょう。
+= user_url(@follower)

--- a/app/views/users/_edit_form.html.haml
+++ b/app/views/users/_edit_form.html.haml
@@ -1,0 +1,16 @@
+= form_for(@user) do |f|
+  = render 'shared/error_messages', object: f.object
+  = f.label :name
+  = f.text_field :name, class: 'form-control'
+  = f.label :email
+  = f.email_field :email, class: 'form-control'
+  = f.label :password
+  = f.password_field :password, class: 'form-control'
+  = f.label :password_confirmation
+  = f.password_field :password_confirmation, class: 'form-control'
+  = f.label :notification_option
+  = f.label :ON
+  = f.radio_button 'notification_option', true, class: 'form-control'
+  = f.label :OFF
+  = f.radio_button 'notification_option', false, class: 'form-control'
+  = f.submit yield(:button_text), class: "btn btn-primary"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -3,7 +3,7 @@
 %h1 Update your profile
 .row
   .col-md-6.col-md-offset-3
-    = render 'form'
+    = render 'edit_form'
     .gravatar_edit
       = gravatar_for @user
       %a{:href => "http://gravatar.com/emails", :rel => "noopener", :target => "_blank"} change

--- a/db/migrate/20170510063344_add_notification_to_users.rb
+++ b/db/migrate/20170510063344_add_notification_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotificationToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :notification_option, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170508085706) do
+ActiveRecord::Schema.define(version: 20170510063344) do
 
   create_table "microposts", force: :cascade do |t|
     t.text     "content"
@@ -35,16 +35,17 @@ ActiveRecord::Schema.define(version: 20170508085706) do
   create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "password_digest"
     t.string   "remember_digest"
-    t.boolean  "admin",             default: false
+    t.boolean  "admin",               default: false
     t.string   "activation_digest"
-    t.boolean  "activated",         default: false
+    t.boolean  "activated",           default: false
     t.datetime "activated_at"
     t.string   "reset_digest"
     t.datetime "reset_sent_at"
+    t.boolean  "notification_option", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -37,16 +37,35 @@ RSpec.describe UserMailer, type: :mailer do
 
   describe 'follower_increase_notification' do
     context 'followerが増えた時' do
-      it 'メールで通知する' do
-        user = create(:michael)
-        other = create(:archer)
+      context 'フォローされたユーザーのnotification_optionがtrue' do
+        it 'メールで通知する' do
+          user = create(:michael)
+          other = create(:archer)
 
-        mail = UserMailer.follower_increase_notification(other, user)
+          expect(user.notification_option).to be_truthy
 
-        expect(mail.subject).to eq('follower increase!')
-        expect(mail.to).to eq([user.email])
-        expect(mail.from).to eq(['from@example.com'])
-        expect(mail.body.encoded).to match(other.name)
+          mail = UserMailer.follower_increase_notification(other, user)
+
+          expect(mail.subject).to eq('follower increase!')
+          expect(mail.to).to eq([user.email])
+          expect(mail.from).to eq(['from@example.com'])
+          expect(mail.body.encoded).to match(other.name)
+        end
+      end
+
+      context 'フォローされたユーザーのnotification_optionがfalse' do
+        it 'メールで通知しない' do
+          user = create(:michael)
+          user.notification_option = false
+
+          other = create(:archer)
+
+          expect(user.notification_option).to be_falsey
+
+          mail = UserMailer.follower_increase_notification(other, user)
+
+          expect(mail.to.nil?).to be_truthy
+        end
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -30,9 +30,24 @@ RSpec.describe UserMailer, type: :mailer do
 
       expect(mail.subject).to eq('Password reset')
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(['from@example.com'])
       expect(mail.body.encoded).to match(user.reset_token)
       expect(mail.body.encoded).to match(CGI.escape(user.email))
+    end
+  end
+
+  describe 'follower_increase_notification' do
+    context 'followerが増えた時' do
+      it 'メールで通知する' do
+        user = create(:michael)
+        other = create(:archer)
+
+        mail = UserMailer.follower_increase_notification(other, user)
+
+        expect(mail.subject).to eq('follower increase!')
+        expect(mail.to).to eq([user.email])
+        expect(mail.from).to eq(['from@example.com'])
+        expect(mail.body.encoded).to match(other.name)
+      end
     end
   end
 end

--- a/spec/requests/users_edits_spec.rb
+++ b/spec/requests/users_edits_spec.rb
@@ -70,5 +70,22 @@ RSpec.describe 'UsersEdits', type: :request do
         expect(@user.reload.email).to eq(email)
       end
     end
+
+    describe 'notification option' do
+      context '通知オプションをオフにした時' do
+        before do
+          fill_in 'Name', with: name
+          fill_in 'Email', with: email
+          fill_in 'Password', with: ''
+          fill_in 'Password confirmation', with: ''
+          choose 'user_notification_option_false'
+
+          click_button 'Save changes'
+        end
+        it 'DBに反映する' do
+          expect(@user.reload.notification_option).to be_falsey
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
フォロワーの通知機能を追加した

ユーザーに新しくフォロワーが増えたときにメールで通知する機能を追加した。
ユーザーに新たに通知オプション（notification_option）カラムを追加し、オプションがFalseの場合はメールを送信しない。